### PR TITLE
FIX: send client name through socket as part of the message itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*.log
+*.log*
 target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/

--- a/src/main/java/com/yahia/anotherchatapplicatoin/app/Main.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/app/Main.java
@@ -1,10 +1,12 @@
 package com.yahia.anotherchatapplicatoin.app;
-
-import com.yahia.anotherchatapplicatoin.client.Client;
 import com.yahia.anotherchatapplicatoin.server.Server;
 
 public class Main {
     public static void main(String[] args) {
-
+        //TODO: Auto-discovery of the server on LAN (clients won't need to type the Server's IP)
+        //TODO: Auto-discovery: App broadcasts a UDP packet, Server replies with it's IP/PORT, clients automatically connects
+        //TODO: Other option: DNS the Server IPs to make it more human friendly
+        Server chatServer = new Server(8080);
+        chatServer.start();
     }
 }

--- a/src/main/java/com/yahia/anotherchatapplicatoin/app/MainApplication.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/app/MainApplication.java
@@ -2,6 +2,7 @@ package com.yahia.anotherchatapplicatoin.app;
 
 import com.yahia.anotherchatapplicatoin.scenes.ChatScene;
 import com.yahia.anotherchatapplicatoin.scenes.LoginScene;
+import com.yahia.anotherchatapplicatoin.server.Server;
 import com.yahia.anotherchatapplicatoin.utils.ui.UiUtils;
 import javafx.application.Application;
 import javafx.scene.control.Alert;
@@ -11,8 +12,6 @@ public class MainApplication extends Application {
     @Override
     //TODO: re-write after setting up the controllers
     public void start(Stage stage){
-//        Server chatServer = new Server(8080);
-//        chatServer.start();
         LoginScene loginScene = new LoginScene();
         loginScene.getLoginButton().setOnAction(actionEvent -> {
             try {

--- a/src/main/java/com/yahia/anotherchatapplicatoin/app/MainApplication.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/app/MainApplication.java
@@ -1,9 +1,7 @@
 package com.yahia.anotherchatapplicatoin.app;
 
-import com.yahia.anotherchatapplicatoin.client.Client;
 import com.yahia.anotherchatapplicatoin.scenes.ChatScene;
 import com.yahia.anotherchatapplicatoin.scenes.LoginScene;
-import com.yahia.anotherchatapplicatoin.server.Server;
 import com.yahia.anotherchatapplicatoin.utils.ui.UiUtils;
 import javafx.application.Application;
 import javafx.scene.control.Alert;
@@ -13,8 +11,8 @@ public class MainApplication extends Application {
     @Override
     //TODO: re-write after setting up the controllers
     public void start(Stage stage){
-        Server chatServer = new Server(8080);
-        chatServer.start();
+//        Server chatServer = new Server(8080);
+//        chatServer.start();
         LoginScene loginScene = new LoginScene();
         loginScene.getLoginButton().setOnAction(actionEvent -> {
             try {

--- a/src/main/java/com/yahia/anotherchatapplicatoin/client/Client.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/client/Client.java
@@ -30,7 +30,7 @@ public class Client {
     }
 
     public void sendMessage(String message) {
-        out.println(message);
+        out.println(prefixMessage(clientName, message));
     }
 
     public void setClientName(String name) {
@@ -40,6 +40,11 @@ public class Client {
     public String getClientName() {
         return clientName;
     }
+
+    private String prefixMessage(String name, String message) {
+        return String.format("[%s]: %s", name, message);
+    }
+
     private void initMessengers(){
         try {
             in = new BufferedReader(new InputStreamReader(clientSocket.getInputStream()));

--- a/src/main/java/com/yahia/anotherchatapplicatoin/controllers/ChatSceneController.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/controllers/ChatSceneController.java
@@ -41,12 +41,10 @@ public class ChatSceneController {
         });
     }
 
-    private String prefixMessage(String message) {
-        return String.format("[%s]: %s\n", client.getClientName(), message);
-    }
+
 
     private void onMessageReceived(String msg) {
-        Platform.runLater(() -> chatArea.appendText(prefixMessage(msg)));
+        Platform.runLater(() -> chatArea.appendText(msg + "\n"));
     }
 
 }


### PR DESCRIPTION
### Summary

Move the responsibility for attaching the client’s username to outgoing messages from **ChatSceneController** to the **Client** class.

### Problem

Each user has their own **ChatSceneController**, and the controller used the current client's username when sending messages.
This caused every client to think they were the sender.

Example:

Ahmed sends a message → Mohamed’s screen shows it as sent by Mohamed.

### Fix

The Client class now prefixes its own username to every message before sending it to the server.
This ensures all clients receive the correct sender name.