### PR TITLE
FIX: wrong alert shows up when client closes the app window

### DIFF
--- a/src/main/java/com/yahia/anotherchatapplicatoin/app/Main.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/app/Main.java
@@ -21,7 +21,7 @@ public class Main {
 //        CommunicationPacket recPacket = JsonHelper.GSON.fromJson(JsonHelper.GSON.toJson(sentPacket), CommunicationPacket.class);
 //        HandShakeRequest req = JsonHelper.GSON.fromJson(recPacket.payload(), HandShakeRequest.class);
 //        System.out.println(req.username());
-        Server chatServer = new Server(8080);
+        Server chatServer = new Server(8082);
         chatServer.start();
     }
 }

--- a/src/main/java/com/yahia/anotherchatapplicatoin/client/Client.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/client/Client.java
@@ -23,7 +23,7 @@ public class Client extends AbstractClient{
     private MessageListener messageListener;
     private HandShakeListener handShakeListener;
     private ServerEventsListener serverEventsListener;
-    private volatile boolean userFiresDisconnect = false;
+    private volatile DisconnectReason disconnectReason;
 
     //TODO: client fetches the server's old messages when connected
     //TODO: introduce ClientController that implements ClientListener
@@ -60,7 +60,7 @@ public class Client extends AbstractClient{
         return clientName;
     }
 
-    public void closeClientSocket() {
+    private void closeClientSocket() {
         try {
             LOGGER.log(Level.INFO, "Closing client socket");
             clientSocket.close();
@@ -69,16 +69,16 @@ public class Client extends AbstractClient{
         }
     }
 
-    public void logout() {
-        userFiresDisconnect = true;
+    public void disconnect() {
         requestDisconnect();
         closeClientSocket();
     }
 
     //TODO: show disclaimer to the client before closing the window
-    public void requestDisconnect() {
+    private void requestDisconnect() {
         String info = JsonHelper.GSON.toJson(new DisconnectRequest(clientName));
         sendMessage(JsonHelper.GSON.toJson(new CommunicationPacket(MessageType.DISCONNECT_REQUEST, info)));
+
     }
 
     public void broadCastUserMessage(String text) {
@@ -126,14 +126,20 @@ public class Client extends AbstractClient{
         }catch (IOException e) {
             LOGGER.log(Level.SEVERE, "Socket between client and server is closed");
         }finally {
-            notifyServerEventListener();
+            setDisconnectReason(DisconnectReason.SERVER_SHUTDOWN);
+            notifyDisconnect(disconnectReason);
         }
 
     }
 
+    //TODO: isn't it a bit dangerous ? everyone can set the disconnection reason
+    public void setDisconnectReason(DisconnectReason reason) {
+        if(disconnectReason == null) disconnectReason = reason;
+    }
     private void handleHandShakeResponse(CommunicationPacket packet) {
         HandShakeResponse handShakeResponse = JsonHelper.GSON.fromJson(packet.payload(), HandShakeResponse.class);
         if(handShakeResponse.status() != ConnectionStatus.ACCEPT) {
+            setDisconnectReason(DisconnectReason.HANDSHAKE_FAILED);
             closeClientSocket();
         }
         notifyHandShakeListener(handShakeResponse.status());
@@ -144,10 +150,10 @@ public class Client extends AbstractClient{
         notifyMessageListener(broadCastMessage);
     }
 
-    private void notifyServerEventListener() {
-        if(serverEventsListener != null && !userFiresDisconnect) {
-            LOGGER.log(Level.INFO, "notifying the server shutting down");
-            serverEventsListener.onServerShutDown();
+    private void notifyDisconnect(DisconnectReason reason) {
+        if(serverEventsListener != null) {
+            LOGGER.log(Level.INFO, String.format("notifying the server for event %s", reason));
+            serverEventsListener.onDisconnect(reason);
         }
     }
 

--- a/src/main/java/com/yahia/anotherchatapplicatoin/client/listeners/ServerEventsListener.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/client/listeners/ServerEventsListener.java
@@ -1,8 +1,11 @@
 package com.yahia.anotherchatapplicatoin.client.listeners;
 
 
+import com.yahia.anotherchatapplicatoin.protocol.DisconnectReason;
+
 //NOTE: is an interface holding only one abstract method, like Runnable, more methods give compiler errors
+//TODO: better naming, its only one event
 @FunctionalInterface
 public interface ServerEventsListener {
-    void onServerShutDown();
+    void onDisconnect(DisconnectReason reason);
 }

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/DisconnectReason.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/DisconnectReason.java
@@ -1,0 +1,8 @@
+package com.yahia.anotherchatapplicatoin.protocol;
+
+public enum DisconnectReason {
+    USER_LOGOUT,
+    WINDOW_CLOSED,
+    SERVER_SHUTDOWN,
+    HANDSHAKE_FAILED,
+}

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/DisconnectRequest.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/DisconnectRequest.java
@@ -1,3 +1,4 @@
 package com.yahia.anotherchatapplicatoin.protocol;
 
+//TODO: later add a disconnectionReason parameter for the server to decide it will shutdown or keep running
 public record DisconnectRequest(String username) {}

--- a/src/main/java/com/yahia/anotherchatapplicatoin/ui/controllers/ChatSceneController.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/ui/controllers/ChatSceneController.java
@@ -10,10 +10,13 @@ import com.yahia.anotherchatapplicatoin.protocol.*;
 import com.yahia.anotherchatapplicatoin.protocol.BroadCastMessage;
 import javafx.application.Platform;
 import javafx.scene.control.Alert;
+import javafx.scene.control.ButtonType;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 
+import javax.swing.text.html.Option;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -54,27 +57,38 @@ public class ChatSceneController implements ChatSceneListener {
 
     @Override
     public void onWindowClosed() {
-        client.requestDisconnect();
-        client.closeClientSocket();
+        client.setDisconnectReason(DisconnectReason.WINDOW_CLOSED);
+        client.disconnect();
+
     }
 
     @Override
     public void onUserExit() {
-        client.logout();
-        navigator.showLoginScene();
+        client.setDisconnectReason(DisconnectReason.USER_LOGOUT);
+        client.disconnect();
     }
 
     private void initListeners() {
         client.setMessageHandler(this::onMessageReceived);
-        client.setServerEventsListener(this::onServerShutDown);
+        client.setServerEventsListener(this::onDisconnect);
     }
 
 
-    //TODO: ServerClientHandler should have instance of ServerEventListener to call this method when handler shuts down
-    public void onServerShutDown() {
+    //TODO: a better way ?
+    public void onDisconnect(DisconnectReason reason) {
         Platform.runLater(() -> {
-            AlertUtils.createAlert(Alert.AlertType.ERROR, "Server has been shut down", "Failed to connect to server").showAndWait();
-            navigator.showLoginScene();
+            switch (reason) {
+                case SERVER_SHUTDOWN -> {
+                    AlertUtils.error("Server has been shut down", "Failed to connect to server").showAndWait();
+                    navigator.showLoginScene();
+                }
+                case USER_LOGOUT -> {
+                    navigator.showLoginScene();
+                }
+                case WINDOW_CLOSED, HANDSHAKE_FAILED -> {
+                    // left blank in purpose
+                }
+            }
         });
     }
 }

--- a/src/main/java/com/yahia/anotherchatapplicatoin/ui/controllers/LoginSceneController.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/ui/controllers/LoginSceneController.java
@@ -31,10 +31,10 @@ public class LoginSceneController implements LoginSceneListener {
     private void onHandShakeStatusReceived(ConnectionStatus status) {
         Platform.runLater(() -> {
             if(status == ConnectionStatus.ACCEPT) {
-                AlertUtils.createAlert(Alert.AlertType.INFORMATION, "Logged In", status.message()).showAndWait();
+                AlertUtils.info("Logged In", status.message()).showAndWait();
                 navigator.showChatScene(client);
             }else {
-                AlertUtils.createAlert(Alert.AlertType.WARNING, "Login Failed", status.message()).showAndWait();
+                AlertUtils.warn("Login Failed", status.message()).showAndWait();
             }
         });
     }
@@ -53,7 +53,7 @@ public class LoginSceneController implements LoginSceneListener {
             sendHandShake();
         }catch(IOException e) {
             LOGGER.log(Level.SEVERE, String.format("Client %s couldn't reach the server %s:%d", username, ipAddress, port));
-            AlertUtils.createAlert(Alert.AlertType.WARNING, String.format("there is no running server at %s:%d", ipAddress, port), "Login Failed").showAndWait();
+            AlertUtils.warn(String.format("there is no running server at %s:%d", ipAddress, port), "Login Failed").showAndWait();
         }
     }
 }

--- a/src/main/java/com/yahia/anotherchatapplicatoin/ui/scenes/ChatScene.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/ui/scenes/ChatScene.java
@@ -1,15 +1,18 @@
 package com.yahia.anotherchatapplicatoin.ui.scenes;
 
 import com.yahia.anotherchatapplicatoin.ui.scenes.listeners.ChatSceneListener;
+import com.yahia.anotherchatapplicatoin.utils.alerts.AlertUtils;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.*;
 import javafx.stage.Stage;
 
+import java.util.Optional;
 
 
 public class ChatScene extends AbstractChatScene{
@@ -49,12 +52,21 @@ public class ChatScene extends AbstractChatScene{
             chatSceneListener.onSendButtonClicked();
         });
 
+
         stage.setOnCloseRequest(windowEvent -> {
-            chatSceneListener.onWindowClosed();
+            Optional<ButtonType> result = AlertUtils.confirm("Are you sure you want to quit ?", "Exit").showAndWait();
+            if(result.isPresent() && result.get() == ButtonType.OK){
+                chatSceneListener.onWindowClosed();
+            }else {
+                windowEvent.consume();
+            }
         });
 
         logoutButton.setOnAction(actionEvent -> {
-            chatSceneListener.onUserExit();
+            Optional<ButtonType> result =  AlertUtils.confirm("Are you sure you want to logout ?", "Logout").showAndWait();
+            if(result.isPresent() && result.get() == ButtonType.OK) {
+                chatSceneListener.onUserExit();
+            }
         });
     }
 

--- a/src/main/java/com/yahia/anotherchatapplicatoin/utils/alerts/AlertUtils.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/utils/alerts/AlertUtils.java
@@ -3,11 +3,39 @@ package com.yahia.anotherchatapplicatoin.utils.alerts;
 import javafx.scene.control.Alert;
 
 public class AlertUtils {
-    public static Alert createAlert(Alert.AlertType type, String message, String header) {
-        Alert alert = new Alert(type, message);
-        alert.setTitle(type.toString());
+
+    public static Alert error(String message, String header) {
+        Alert alert = new Alert(Alert.AlertType.ERROR, message);
+        alert.setTitle(Alert.AlertType.ERROR.toString());
         alert.setHeaderText(header);
         return alert;
     }
+
+    public static Alert confirm(String message, String header) {
+        Alert alert = new Alert(Alert.AlertType.CONFIRMATION, message);
+        alert.setTitle(Alert.AlertType.CONFIRMATION.toString());
+        alert.setHeaderText(header);
+        return alert;
+    }
+    public static Alert warn(String message, String header) {
+        Alert alert = new Alert(Alert.AlertType.WARNING, message);
+        alert.setTitle(Alert.AlertType.WARNING.toString());
+        alert.setHeaderText(header);
+        return alert;
+    }
+
+    public static Alert info(String message, String header) {
+        Alert alert = new Alert(Alert.AlertType.INFORMATION, message);
+        alert.setTitle(Alert.AlertType.INFORMATION.toString());
+        alert.setHeaderText(header);
+        return alert;
+    }
+    public static Alert none(String message, String header) {
+        Alert alert = new Alert(Alert.AlertType.NONE, message);
+        alert.setTitle(Alert.AlertType.NONE.toString());
+        alert.setHeaderText(header);
+        return alert;
+    }
+
     private AlertUtils() {}
 }


### PR DESCRIPTION
# Centralize Disconnect Logic

## Summary
In this PR we are replaceing the previous ad-hoc volatile flag approach with a `DisconnectReason` enum, to handle multiple disconnect scenarios

## Changes
### 1. `DisconnectReason` enum
- Enumerates possible reasons for client disconnection:
  - `SERVER_SHUTDOWN`
  - `USER_LOGOUT`
  - `WINDOW_CLOSED`
  - `HANDSHAKE_FAILED`

### 3. Updated `listen()` loop in `Client`
- Socket read loop now calls `notifyDisconnect(disconnectReason)` in `finally`.
- `SERVER_SHUTDOWN` is set as fallback only if no other reason was previously set.

### 4. Disconnect handling in `ChatSceneController` 
- `onDisconnect(DisconnectReason reason)` handles the chat scene navigation and alerts in one place:
  - `SERVER_SHUTDOWN` → show error alert, navigate to login scene
  - `USER_LOGOUT` → navigate to login scene
  - `WINDOW_CLOSED` and `HANDSHAKE_FAILED` → no UI action (login scene controller handles handshake failures), it may be improved later

