### PR TITLE
Refactor/messaging abstraction

### DIFF
--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/packet/PacketHandler.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/packet/PacketHandler.java
@@ -1,6 +1,8 @@
 package com.yahia.anotherchatapplicatoin.protocol.packet;
 
+import java.io.IOException;
+
 @FunctionalInterface
 public interface PacketHandler {
-    void handlePacket(CommunicationPacket packet);
+    void handlePacket(CommunicationPacket packet) throws IOException;
 }

--- a/src/main/java/com/yahia/anotherchatapplicatoin/server/Server.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/server/Server.java
@@ -9,6 +9,7 @@ import com.yahia.anotherchatapplicatoin.protocol.messaging.BroadCastMessage;
 import com.yahia.anotherchatapplicatoin.protocol.messaging.MessageReceiver;
 import com.yahia.anotherchatapplicatoin.protocol.messaging.MessageSender;
 import com.yahia.anotherchatapplicatoin.protocol.packet.CommunicationPacket;
+import com.yahia.anotherchatapplicatoin.protocol.packet.PacketHandlerRegistry;
 import com.yahia.anotherchatapplicatoin.protocol.packet.PacketType;
 import com.yahia.anotherchatapplicatoin.transport.tcp.SocketMessageReceiver;
 import com.yahia.anotherchatapplicatoin.transport.tcp.SocketMessageSender;
@@ -35,6 +36,11 @@ public class Server {
     private final Set<String> CLIENT_NAMES;
     private final Logger LOGGER;
     private ServerSocket serverSocket;
+    private final PacketHandlerRegistry handlerRegistry;
+    private Socket clientSocket; // NOTE: overwritten with each new connection
+    private MessageSender sender; //NOTE: overwritten with each new connection
+    private MessageReceiver receiver; //NOTE: overwritten with each new connection
+
 
     //TODO: new server fetches the sent messages from db when initialized
     //TODO: each server deals with it's own data transfer currently
@@ -44,6 +50,9 @@ public class Server {
         CLIENTS = ConcurrentHashMap.newKeySet();
         CLIENT_NAMES = ConcurrentHashMap.newKeySet();
         LOGGER = LogManager.getLogger();
+
+        handlerRegistry = new PacketHandlerRegistry();
+        registerHandlers();
     }
 
     public void start() {
@@ -80,6 +89,9 @@ public class Server {
     }
 
 
+    private void registerHandlers() {
+        handlerRegistry.register(PacketType.HANDSHAKE_REQUEST, this::handleHandshakeRequest);
+    }
 
 
     private void run() throws IOException {
@@ -87,8 +99,7 @@ public class Server {
         LOGGER.log(Level.INFO, String.format("Server running on %s:%d", SocketUtils.getServerSocketAddress(serverSocket), SERVER_PORT));
     }
 
-    private ConnectionStatus handleHandShake(HandshakeRequest handShakeRequest) {
-        LOGGER.log(Level.INFO, "Server Receives a HandShake Request");
+    private ConnectionStatus checkStatus(HandshakeRequest handShakeRequest) {
         if(CLIENT_NAMES.contains(handShakeRequest.username())) {
             return ConnectionStatus.REJECT_USERNAME_TAKEN;
         }
@@ -96,36 +107,34 @@ public class Server {
         return ConnectionStatus.ACCEPT;
     }
 
-    private void handleClient(Socket clientSocket) throws IOException {
-        MessageSender sender = new SocketMessageSender(new PrintWriter(clientSocket.getOutputStream(), true), new JsonPacketEncoder());
-        MessageReceiver receiver = new SocketMessageReceiver(new BufferedReader(new InputStreamReader(clientSocket.getInputStream())), new JsonPacketDecoder());
-        var clientSentPacket = receiver.receive();
-        System.out.println(clientSentPacket);
-        switch(clientSentPacket.type()) {
-            case HANDSHAKE_REQUEST -> {
-                HandshakeRequest handShakeRequest = JsonHelper.GSON.fromJson(clientSentPacket.payload(), HandshakeRequest.class);
-                ConnectionStatus connectionStatus = handleHandShake(handShakeRequest);
-                String response = JsonHelper.GSON.toJson(new HandshakeResponse(connectionStatus));
+    private void handleHandshakeRequest(CommunicationPacket packet) throws IOException {
+        LOGGER.log(Level.INFO, "Server Receives a HandShake Request");
+        HandshakeRequest request = JsonHelper.GSON.fromJson(packet.payload(), HandshakeRequest.class);
+        ConnectionStatus status = checkStatus(request);
+        String response = JsonHelper.GSON.toJson(new HandshakeResponse(status));
 
-                sender.send(new CommunicationPacket(PacketType.HANDSHAKE_RESPONSE, response));
+        sender.send(new CommunicationPacket(PacketType.HANDSHAKE_RESPONSE, response));
 
-                if(connectionStatus == ConnectionStatus.ACCEPT) {
-                    ServerClientHandler clientHandler = new ServerClientHandler(clientSocket, this, handShakeRequest.username());
-                    CLIENTS.add(clientHandler);
-                    LOGGER.log(Level.FINE, String.format("Number of Clients connected to %s is %d", serverSocket.getInetAddress().getHostAddress(), CLIENTS.size()));
-                    new Thread(clientHandler).start();
-                }
-            }
-            default -> LOGGER.log(Level.SEVERE, "UNKNOWN HEADER");
-
+        if(status == ConnectionStatus.ACCEPT) {
+            ServerClientHandler clientHandler = new ServerClientHandler(clientSocket, this, request.username());
+            CLIENTS.add(clientHandler);
+            LOGGER.log(Level.FINE, String.format("Number of Clients connected to %s is %d", serverSocket.getInetAddress().getHostAddress(), CLIENTS.size()));
+            new Thread(clientHandler).start();
         }
+    }
+
+    private void handleClient(Socket clientSocket) throws IOException {
+        sender = new SocketMessageSender(new PrintWriter(clientSocket.getOutputStream(), true), new JsonPacketEncoder());
+        receiver = new SocketMessageReceiver(new BufferedReader(new InputStreamReader(clientSocket.getInputStream())), new JsonPacketDecoder());
+        CommunicationPacket clientSentPacket = receiver.receive();
+        handlerRegistry.get(clientSentPacket.type()).handlePacket(clientSentPacket);
     }
 
     private void listen(){
         new Thread(() -> {
             while(true) {
                 try {
-                    Socket clientSocket = serverSocket.accept();
+                    clientSocket = serverSocket.accept();
                     handleClient(clientSocket);
                 }catch (IOException e) {
                     LOGGER.log(Level.WARNING, "Server couldn't connect to client");

--- a/src/main/java/com/yahia/anotherchatapplicatoin/server/Server.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/server/Server.java
@@ -1,6 +1,8 @@
 package com.yahia.anotherchatapplicatoin.server;
 
-import com.yahia.anotherchatapplicatoin.handlers.ServerClientHandler;
+import com.yahia.anotherchatapplicatoin.server.accept.ServerConnectionContext;
+import com.yahia.anotherchatapplicatoin.server.accept.ServerPacketHandlerRegistry;
+import com.yahia.anotherchatapplicatoin.server.session.ServerClientHandler;
 import com.yahia.anotherchatapplicatoin.protocol.codec.JsonPacketDecoder;
 import com.yahia.anotherchatapplicatoin.protocol.codec.JsonPacketEncoder;
 import com.yahia.anotherchatapplicatoin.protocol.handshake.ConnectionStatus;
@@ -9,7 +11,6 @@ import com.yahia.anotherchatapplicatoin.protocol.messaging.BroadCastMessage;
 import com.yahia.anotherchatapplicatoin.protocol.messaging.MessageReceiver;
 import com.yahia.anotherchatapplicatoin.protocol.messaging.MessageSender;
 import com.yahia.anotherchatapplicatoin.protocol.packet.CommunicationPacket;
-import com.yahia.anotherchatapplicatoin.protocol.packet.PacketHandlerRegistry;
 import com.yahia.anotherchatapplicatoin.protocol.packet.PacketType;
 import com.yahia.anotherchatapplicatoin.transport.tcp.SocketMessageReceiver;
 import com.yahia.anotherchatapplicatoin.transport.tcp.SocketMessageSender;
@@ -29,6 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+//TODO: make the server more like an API, that handles jobs like register/un-register clients, processing handshakes and stuff
 public class Server {
 
     private final int SERVER_PORT;
@@ -36,11 +38,7 @@ public class Server {
     private final Set<String> CLIENT_NAMES;
     private final Logger LOGGER;
     private ServerSocket serverSocket;
-    private final PacketHandlerRegistry handlerRegistry;
-    private Socket clientSocket; // NOTE: overwritten with each new connection
-    private MessageSender sender; //NOTE: overwritten with each new connection
-    private MessageReceiver receiver; //NOTE: overwritten with each new connection
-
+    private final ServerPacketHandlerRegistry serverHandlerRegistry;
 
     //TODO: new server fetches the sent messages from db when initialized
     //TODO: each server deals with it's own data transfer currently
@@ -51,7 +49,7 @@ public class Server {
         CLIENT_NAMES = ConcurrentHashMap.newKeySet();
         LOGGER = LogManager.getLogger();
 
-        handlerRegistry = new PacketHandlerRegistry();
+        serverHandlerRegistry = new ServerPacketHandlerRegistry();
         registerHandlers();
     }
 
@@ -64,22 +62,12 @@ public class Server {
         }
     }
 
-    public String getServerAddress() {
-        return SocketUtils.getServerSocketAddress(serverSocket);
-    }
-    public int getServerPort() {
-        return SERVER_PORT;
-    }
-
     public void broadCastPacket(CommunicationPacket packet) {
         for(ServerClientHandler clientHandler: CLIENTS) {
             clientHandler.sendMessageToClient(packet);
         }
     }
 
-    //TODO: client can disconnect form the server, should rollback ui to login screen
-    //TODO: when disconnected, server should broadcast the info
-    //TODO: use Disconnect Request-Response records
     public void removeClient(ServerClientHandler clientHandler, String clientUsername) {
         CLIENTS.remove(clientHandler);
         CLIENT_NAMES.remove(clientUsername);
@@ -88,9 +76,14 @@ public class Server {
         broadCastPacket(new CommunicationPacket(PacketType.BROADCAST_MESSAGE, info));
     }
 
+    public void registerClient(String username, ServerClientHandler handler) {
+        CLIENTS.add(handler);
+        CLIENT_NAMES.add(username);
+    }
+
 
     private void registerHandlers() {
-        handlerRegistry.register(PacketType.HANDSHAKE_REQUEST, this::handleHandshakeRequest);
+        serverHandlerRegistry.register(PacketType.HANDSHAKE_REQUEST, this::handleHandshakeRequest);
     }
 
 
@@ -103,38 +96,42 @@ public class Server {
         if(CLIENT_NAMES.contains(handShakeRequest.username())) {
             return ConnectionStatus.REJECT_USERNAME_TAKEN;
         }
-        CLIENT_NAMES.add(handShakeRequest.username());
         return ConnectionStatus.ACCEPT;
     }
 
-    private void handleHandshakeRequest(CommunicationPacket packet) throws IOException {
+    private void handleAccept(ServerConnectionContext ctx, HandshakeRequest request) throws IOException {
+        ServerClientHandler clientHandler = new ServerClientHandler(ctx.clientSocket(), this, request.username());
+        registerClient(request.username(), clientHandler);
+        LOGGER.log(Level.FINE, String.format("Number of Clients connected to %s is %d", serverSocket.getInetAddress().getHostAddress(), CLIENTS.size()));
+        new Thread(clientHandler).start();
+    }
+
+    private void handleHandshakeRequest(ServerConnectionContext ctx) throws IOException {
+        CommunicationPacket packet = ctx.receiver().receive();
+
         LOGGER.log(Level.INFO, "Server Receives a HandShake Request");
         HandshakeRequest request = JsonHelper.GSON.fromJson(packet.payload(), HandshakeRequest.class);
         ConnectionStatus status = checkStatus(request);
         String response = JsonHelper.GSON.toJson(new HandshakeResponse(status));
 
-        sender.send(new CommunicationPacket(PacketType.HANDSHAKE_RESPONSE, response));
+        ctx.sender().send(new CommunicationPacket(PacketType.HANDSHAKE_RESPONSE, response));
 
         if(status == ConnectionStatus.ACCEPT) {
-            ServerClientHandler clientHandler = new ServerClientHandler(clientSocket, this, request.username());
-            CLIENTS.add(clientHandler);
-            LOGGER.log(Level.FINE, String.format("Number of Clients connected to %s is %d", serverSocket.getInetAddress().getHostAddress(), CLIENTS.size()));
-            new Thread(clientHandler).start();
+           handleAccept(ctx, request);
         }
     }
 
     private void handleClient(Socket clientSocket) throws IOException {
-        sender = new SocketMessageSender(new PrintWriter(clientSocket.getOutputStream(), true), new JsonPacketEncoder());
-        receiver = new SocketMessageReceiver(new BufferedReader(new InputStreamReader(clientSocket.getInputStream())), new JsonPacketDecoder());
-        CommunicationPacket clientSentPacket = receiver.receive();
-        handlerRegistry.get(clientSentPacket.type()).handlePacket(clientSentPacket);
+       MessageSender sender = new SocketMessageSender(new PrintWriter(clientSocket.getOutputStream(), true), new JsonPacketEncoder());
+       MessageReceiver receiver = new SocketMessageReceiver(new BufferedReader(new InputStreamReader(clientSocket.getInputStream())), new JsonPacketDecoder());
+       handleHandshakeRequest(new ServerConnectionContext(sender, receiver, clientSocket));
     }
 
     private void listen(){
         new Thread(() -> {
             while(true) {
                 try {
-                    clientSocket = serverSocket.accept();
+                    Socket clientSocket = serverSocket.accept();
                     handleClient(clientSocket);
                 }catch (IOException e) {
                     LOGGER.log(Level.WARNING, "Server couldn't connect to client");

--- a/src/main/java/com/yahia/anotherchatapplicatoin/server/accept/ServerConnectionContext.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/server/accept/ServerConnectionContext.java
@@ -1,0 +1,12 @@
+package com.yahia.anotherchatapplicatoin.server.accept;
+
+import com.yahia.anotherchatapplicatoin.protocol.messaging.MessageReceiver;
+import com.yahia.anotherchatapplicatoin.protocol.messaging.MessageSender;
+
+import java.net.Socket;
+
+public record ServerConnectionContext(
+        MessageSender sender,
+        MessageReceiver receiver,
+        Socket clientSocket)
+{}

--- a/src/main/java/com/yahia/anotherchatapplicatoin/server/accept/ServerPacketHandler.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/server/accept/ServerPacketHandler.java
@@ -1,0 +1,10 @@
+package com.yahia.anotherchatapplicatoin.server.accept;
+
+import com.yahia.anotherchatapplicatoin.protocol.packet.CommunicationPacket;
+
+import java.io.IOException;
+
+@FunctionalInterface
+public interface ServerPacketHandler {
+    void handle(ServerConnectionContext ctx) throws IOException;
+}

--- a/src/main/java/com/yahia/anotherchatapplicatoin/server/accept/ServerPacketHandlerRegistry.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/server/accept/ServerPacketHandlerRegistry.java
@@ -1,0 +1,19 @@
+package com.yahia.anotherchatapplicatoin.server.accept;
+
+import com.yahia.anotherchatapplicatoin.protocol.packet.PacketType;
+
+import java.util.HashMap;
+
+public class ServerPacketHandlerRegistry {
+    private final HashMap<PacketType, ServerPacketHandler> serverHandlers = new HashMap<>();
+
+    public ServerPacketHandlerRegistry(){}
+
+    public void register(PacketType type, ServerPacketHandler handler) {
+        serverHandlers.put(type, handler);
+    }
+
+    public ServerPacketHandler get(PacketType type) {
+        return serverHandlers.get(type);
+    }
+}

--- a/src/main/java/com/yahia/anotherchatapplicatoin/server/session/ServerClientHandler.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/server/session/ServerClientHandler.java
@@ -1,4 +1,4 @@
-package com.yahia.anotherchatapplicatoin.handlers;
+package com.yahia.anotherchatapplicatoin.server.session;
 
 import com.yahia.anotherchatapplicatoin.protocol.disconnect.DisconnectRequest;
 import com.yahia.anotherchatapplicatoin.protocol.json.JsonHelper;

--- a/src/main/java/com/yahia/anotherchatapplicatoin/transport/tcp/SocketMessageSender.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/transport/tcp/SocketMessageSender.java
@@ -3,7 +3,10 @@ package com.yahia.anotherchatapplicatoin.transport.tcp;
 import com.yahia.anotherchatapplicatoin.protocol.codec.PacketEncoder;
 import com.yahia.anotherchatapplicatoin.protocol.messaging.MessageSender;
 import com.yahia.anotherchatapplicatoin.protocol.packet.CommunicationPacket;
+
+import javax.swing.plaf.nimbus.State;
 import java.io.PrintWriter;
+import java.util.UUID;
 
 public class SocketMessageSender implements MessageSender {
     private final PrintWriter out;

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -14,8 +14,6 @@ module org.example.anotherchatapplicatoin {
     opens com.yahia.anotherchatapplicatoin.client to javafx.fxml;
     exports com.yahia.anotherchatapplicatoin.server;
     opens com.yahia.anotherchatapplicatoin.server to javafx.fxml;
-    exports com.yahia.anotherchatapplicatoin.handlers;
-    opens com.yahia.anotherchatapplicatoin.handlers to javafx.fxml;
     opens com.yahia.anotherchatapplicatoin.utils.ui to javafx.fxml;
     exports com.yahia.anotherchatapplicatoin.utils.ui;
     opens com.yahia.anotherchatapplicatoin.client.listeners to javafx.fxml;
@@ -38,4 +36,6 @@ module org.example.anotherchatapplicatoin {
     opens com.yahia.anotherchatapplicatoin.protocol.handshake to javafx.fxml;
     exports com.yahia.anotherchatapplicatoin.protocol.json;
     opens com.yahia.anotherchatapplicatoin.protocol.json to javafx.fxml;
+    opens com.yahia.anotherchatapplicatoin.server.session to javafx.fxml;
+    exports com.yahia.anotherchatapplicatoin.server.session;
 }


### PR DESCRIPTION
## Handshake context and server-side packet handler registry

## Problem

Previously, the server stored per-connection state (socket, sender, receiver) as mutable class fields, which may lead to concurrency issues and heisenbugs later

---

## Summary

A refactor of server connection handshake flow by introducing a **server-side handshake context** and a **dedicated packet handler registry for the server accept/handshake phase**.

The main goal is to separate only:
- **protocol-level packet handling** (client + server sessions / client handlers)
- **server-only initialization logic per each client** (accept / handshake)

The main reason behind this refactor is to remove the hidden shared state from the `Server` class and makes per-connection data explicit and immutable
---

## Changes

### 1. Handshake Context (Record)
- A lightweight, immutable context object for the server accept phase.
- Encapsulates per-connection state:
  - socket  
  - sender  
  - receiver
- Scoped strictly to the pre-session lifecycle

---

### 2. Server-side Packet Handler Interface
- A dedicated packet handler interface for the pre-session phase.
- Allows handlers to access pre-session specific context without polluting the generic `PacketHandler` interface.
- Leave protocol handlers untouched for the client and server

---
