### PR TITLE
Refactor/messaging abstraction

### DIFF
--- a/src/main/java/com/yahia/anotherchatapplicatoin/client/AbstractClient.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/client/AbstractClient.java
@@ -8,8 +8,8 @@ public abstract class AbstractClient {
         connect(serverIp, port);
         initMessengers();
         registerHandlers();
-        registerEncoders();
-        registerDecoders();
+//        registerEncoders();
+//        registerDecoders();
         startListener();
     }
 
@@ -17,6 +17,4 @@ public abstract class AbstractClient {
     protected abstract void initMessengers();
     protected abstract void startListener();
     protected abstract void registerHandlers();
-    protected abstract void registerEncoders();
-    protected abstract void registerDecoders();
 }

--- a/src/main/java/com/yahia/anotherchatapplicatoin/client/AbstractClient.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/client/AbstractClient.java
@@ -8,6 +8,8 @@ public abstract class AbstractClient {
         connect(serverIp, port);
         initMessengers();
         registerHandlers();
+        registerEncoders();
+        registerDecoders();
         startListener();
     }
 
@@ -15,4 +17,6 @@ public abstract class AbstractClient {
     protected abstract void initMessengers();
     protected abstract void startListener();
     protected abstract void registerHandlers();
+    protected abstract void registerEncoders();
+    protected abstract void registerDecoders();
 }

--- a/src/main/java/com/yahia/anotherchatapplicatoin/client/Client.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/client/Client.java
@@ -3,8 +3,18 @@ package com.yahia.anotherchatapplicatoin.client;
 import com.yahia.anotherchatapplicatoin.client.listeners.HandshakeListener;
 import com.yahia.anotherchatapplicatoin.client.listeners.MessageListener;
 import com.yahia.anotherchatapplicatoin.client.listeners.DisconnectListener;
-import com.yahia.anotherchatapplicatoin.protocol.codec.JsonPacketDecoder;
-import com.yahia.anotherchatapplicatoin.protocol.codec.JsonPacketEncoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.packet.json.JsonPacketDecoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.packet.json.JsonPacketEncoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.PayloadDecoderRegistry;
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.PayloadEncoderRegistry;
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.disconnect.JsonDisconnectRequestDecoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.disconnect.JsonDisconnectRequestEncoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.handshake.JsonHandshakeRequestDecoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.handshake.JsonHandshakeRequestEncoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.handshake.JsonHandshakeResponseDecoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.handshake.JsonHandshakeResponseEncoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.messinging.JsonBroadcastMessageDecoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.messinging.JsonBroadcastMessageEncoder;
 import com.yahia.anotherchatapplicatoin.protocol.disconnect.DisconnectReason;
 import com.yahia.anotherchatapplicatoin.protocol.disconnect.DisconnectRequest;
 import com.yahia.anotherchatapplicatoin.protocol.handshake.ConnectionStatus;
@@ -32,14 +42,19 @@ public class Client extends AbstractClient{
     private MessageListener messageListener;
     private HandshakeListener handShakeListener;
     private DisconnectListener serverEventsListener;
-    private volatile DisconnectReason disconnectReason;
-    private final PacketHandlerRegistry handlerRegistry;
     private MessageSender sender;
     private MessageReceiver receiver;
-    //TODO: client fetches the server's old messages when connected
+    private volatile DisconnectReason disconnectReason;
+    private final PacketHandlerRegistry handlerRegistry;
+    private final PayloadDecoderRegistry decoderRegistry;
+    private final PayloadEncoderRegistry encoderRegistry;
+
+    //TODO: client fetches the server's old messages when connected, from a NoSQL DB
     public Client(String clientName, String serverIp, int port) throws IOException {
         this.clientName = clientName;
         handlerRegistry = new PacketHandlerRegistry();
+        decoderRegistry = new PayloadDecoderRegistry(); //TODO: will use later
+        encoderRegistry = new PayloadEncoderRegistry(); //TODO: will use later
         startNewClient(serverIp, port);
     }
 
@@ -126,6 +141,18 @@ public class Client extends AbstractClient{
         handlerRegistry.register(PacketType.BROADCAST_MESSAGE, this::handleBroadCastMessage);
     }
 
+    @Override
+    protected void registerEncoders() {
+        encoderRegistry.register(PacketType.HANDSHAKE_REQUEST, new JsonHandshakeRequestEncoder());
+        encoderRegistry.register(PacketType.BROADCAST_MESSAGE, new JsonBroadcastMessageEncoder());
+    }
+
+    @Override
+    protected void registerDecoders() {
+        decoderRegistry.register(PacketType.HANDSHAKE_RESPONSE, new JsonHandshakeResponseDecoder());
+        decoderRegistry.register(PacketType.BROADCAST_MESSAGE, new JsonBroadcastMessageDecoder());
+    }
+
     private void listen() {
         CommunicationPacket packet;
         try {
@@ -148,17 +175,20 @@ public class Client extends AbstractClient{
     }
 
     private void requestDisconnect() {
-        String info = JsonHelper.GSON.toJson(new DisconnectRequest(clientName));
+        JsonDisconnectRequestEncoder decoder = new JsonDisconnectRequestEncoder();
+        String info = decoder.encode(new DisconnectRequest(clientName));
         sendMessage(new CommunicationPacket(PacketType.DISCONNECT_REQUEST, info));
     }
 
     private void handleHandShakeResponse(CommunicationPacket packet) {
-        HandshakeResponse handShakeResponse = JsonHelper.GSON.fromJson(packet.payload(), HandshakeResponse.class);
+        JsonHandshakeResponseDecoder decoder = new JsonHandshakeResponseDecoder();
+        HandshakeResponse handShakeResponse = decoder.decode(packet.payload());
         notifyHandShakeListener(handShakeResponse.status());
     }
 
     private void handleBroadCastMessage(CommunicationPacket packet) {
-        BroadCastMessage broadCastMessage = JsonHelper.GSON.fromJson(packet.payload(), BroadCastMessage.class);
+        JsonBroadcastMessageDecoder decoder = new JsonBroadcastMessageDecoder();
+        BroadCastMessage broadCastMessage = decoder.decode(packet.payload());
         notifyMessageListener(broadCastMessage);
     }
 
@@ -181,8 +211,9 @@ public class Client extends AbstractClient{
     }
 
     private void broadCastInternal(String sender, String text) {
-        BroadCastMessage broadCastMessage = new BroadCastMessage(sender, text);
-        sendMessage(new CommunicationPacket(PacketType.BROADCAST_MESSAGE, JsonHelper.GSON.toJson(broadCastMessage)));
+        JsonBroadcastMessageEncoder encoder = new JsonBroadcastMessageEncoder();
+        BroadCastMessage msg = new BroadCastMessage(sender, text);
+        sendMessage(new CommunicationPacket(PacketType.BROADCAST_MESSAGE, encoder.encode(msg)));
     }
 
     private String prefixName(String name, String message) {

--- a/src/main/java/com/yahia/anotherchatapplicatoin/client/Client.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/client/Client.java
@@ -46,15 +46,12 @@ public class Client extends AbstractClient{
     private MessageReceiver receiver;
     private volatile DisconnectReason disconnectReason;
     private final PacketHandlerRegistry handlerRegistry;
-    private final PayloadDecoderRegistry decoderRegistry;
-    private final PayloadEncoderRegistry encoderRegistry;
+
 
     //TODO: client fetches the server's old messages when connected, from a NoSQL DB
     public Client(String clientName, String serverIp, int port) throws IOException {
         this.clientName = clientName;
         handlerRegistry = new PacketHandlerRegistry();
-        decoderRegistry = new PayloadDecoderRegistry(); //TODO: will use later
-        encoderRegistry = new PayloadEncoderRegistry(); //TODO: will use later
         startNewClient(serverIp, port);
     }
 
@@ -141,17 +138,6 @@ public class Client extends AbstractClient{
         handlerRegistry.register(PacketType.BROADCAST_MESSAGE, this::handleBroadCastMessage);
     }
 
-    @Override
-    protected void registerEncoders() {
-        encoderRegistry.register(PacketType.HANDSHAKE_REQUEST, new JsonHandshakeRequestEncoder());
-        encoderRegistry.register(PacketType.BROADCAST_MESSAGE, new JsonBroadcastMessageEncoder());
-    }
-
-    @Override
-    protected void registerDecoders() {
-        decoderRegistry.register(PacketType.HANDSHAKE_RESPONSE, new JsonHandshakeResponseDecoder());
-        decoderRegistry.register(PacketType.BROADCAST_MESSAGE, new JsonBroadcastMessageDecoder());
-    }
 
     private void listen() {
         CommunicationPacket packet;
@@ -161,7 +147,7 @@ public class Client extends AbstractClient{
                 handlerRegistry.get(packet.type()).handlePacket(packet);
             }
         }catch (IOException e) {
-            LOGGER.log(Level.SEVERE, "Client socket has been closed");
+            LOGGER.log(Level.SEVERE, String.format("Client socket has been closed: %s", e.getMessage()));
         }finally {
             LOGGER.log(Level.SEVERE, "Server dies");
             disconnect(DisconnectReason.SERVER_SHUTDOWN);

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/packet/PacketDecoder.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/packet/PacketDecoder.java
@@ -1,4 +1,4 @@
-package com.yahia.anotherchatapplicatoin.protocol.codec;
+package com.yahia.anotherchatapplicatoin.protocol.codec.packet;
 import com.yahia.anotherchatapplicatoin.protocol.packet.CommunicationPacket;
 
 //NOTE: decodes raw bytes into CommunicationPacket

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/packet/PacketEncoder.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/packet/PacketEncoder.java
@@ -1,4 +1,4 @@
-package com.yahia.anotherchatapplicatoin.protocol.codec;
+package com.yahia.anotherchatapplicatoin.protocol.codec.packet;
 
 import com.yahia.anotherchatapplicatoin.protocol.packet.CommunicationPacket;
 

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/packet/json/JsonPacketDecoder.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/packet/json/JsonPacketDecoder.java
@@ -1,13 +1,11 @@
-package com.yahia.anotherchatapplicatoin.protocol.codec;
+package com.yahia.anotherchatapplicatoin.protocol.codec.packet.json;
 
+import com.yahia.anotherchatapplicatoin.protocol.codec.packet.PacketDecoder;
 import com.yahia.anotherchatapplicatoin.protocol.json.JsonHelper;
 import com.yahia.anotherchatapplicatoin.protocol.packet.CommunicationPacket;
-import com.yahia.anotherchatapplicatoin.utils.logging.LogManager;
-
-import java.util.logging.Logger;
 
 
-public class JsonPacketDecoder implements PacketDecoder{
+public class JsonPacketDecoder implements PacketDecoder {
 
     @Override
     public CommunicationPacket decode(String raw) {

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/packet/json/JsonPacketEncoder.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/packet/json/JsonPacketEncoder.java
@@ -1,16 +1,14 @@
-package com.yahia.anotherchatapplicatoin.protocol.codec;
+package com.yahia.anotherchatapplicatoin.protocol.codec.packet.json;
 
+import com.yahia.anotherchatapplicatoin.protocol.codec.packet.PacketEncoder;
 import com.yahia.anotherchatapplicatoin.protocol.json.JsonHelper;
 import com.yahia.anotherchatapplicatoin.protocol.packet.CommunicationPacket;
 import com.yahia.anotherchatapplicatoin.utils.logging.LogManager;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.logging.Level;
+
 import java.util.logging.Logger;
 
 
 public class JsonPacketEncoder implements PacketEncoder {
-    private final Logger LOGGER = LogManager.getLogger();
     @Override
     public String encode(CommunicationPacket packet) {
         return JsonHelper.GSON.toJson(packet);

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/PayloadDecoder.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/PayloadDecoder.java
@@ -1,0 +1,5 @@
+package com.yahia.anotherchatapplicatoin.protocol.codec.payload;
+
+public  interface PayloadDecoder <T> {
+    T decode(String raw);
+}

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/PayloadDecoderRegistry.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/PayloadDecoderRegistry.java
@@ -1,0 +1,19 @@
+package com.yahia.anotherchatapplicatoin.protocol.codec.payload;
+
+import com.yahia.anotherchatapplicatoin.protocol.packet.PacketType;
+
+import java.util.HashMap;
+
+public final class PayloadDecoderRegistry {
+    private final HashMap<PacketType, PayloadDecoder<?>> decoders = new HashMap<>();
+
+    public <T> void register(PacketType type, PayloadDecoder<T> decoder) {
+        decoders.put(type, decoder);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> PayloadDecoder<T> get(PacketType type) {
+        if(decoders.get(type) == null) throw new IllegalStateException(String.format("Packet type %s didn't register a decoder", type));
+        return (PayloadDecoder<T>) decoders.get(type);
+    }
+}

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/PayloadEncoder.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/PayloadEncoder.java
@@ -1,0 +1,5 @@
+package com.yahia.anotherchatapplicatoin.protocol.codec.payload;
+
+public interface PayloadEncoder <T>{
+    String encode(T payload);
+}

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/PayloadEncoderRegistry.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/PayloadEncoderRegistry.java
@@ -1,0 +1,19 @@
+package com.yahia.anotherchatapplicatoin.protocol.codec.payload;
+
+import com.yahia.anotherchatapplicatoin.protocol.packet.PacketType;
+
+import java.util.HashMap;
+
+public final class PayloadEncoderRegistry {
+    private final HashMap<PacketType, PayloadEncoder<?>> encoders = new HashMap<>();
+
+    public <T> void register(PacketType type, PayloadEncoder<T> encoder) {
+        encoders.put(type, encoder);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> PayloadEncoder<T> get(PacketType type) {
+        if(encoders.get(type) == null) throw new IllegalStateException(String.format("Packet type %s didn't register an encoder", type));
+        return (PayloadEncoder<T>) encoders.get(type);
+    }
+}

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/json/disconnect/JsonDisconnectRequestDecoder.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/json/disconnect/JsonDisconnectRequestDecoder.java
@@ -1,0 +1,12 @@
+package com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.disconnect;
+
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.PayloadDecoder;
+import com.yahia.anotherchatapplicatoin.protocol.disconnect.DisconnectRequest;
+import com.yahia.anotherchatapplicatoin.protocol.json.JsonHelper;
+
+public class JsonDisconnectRequestDecoder implements PayloadDecoder<DisconnectRequest> {
+    @Override
+    public DisconnectRequest decode(String raw) {
+        return JsonHelper.GSON.fromJson(raw, DisconnectRequest.class);
+    }
+}

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/json/disconnect/JsonDisconnectRequestEncoder.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/json/disconnect/JsonDisconnectRequestEncoder.java
@@ -1,0 +1,12 @@
+package com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.disconnect;
+
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.PayloadEncoder;
+import com.yahia.anotherchatapplicatoin.protocol.disconnect.DisconnectRequest;
+import com.yahia.anotherchatapplicatoin.protocol.json.JsonHelper;
+
+public class JsonDisconnectRequestEncoder implements PayloadEncoder<DisconnectRequest> {
+    @Override
+    public String encode(DisconnectRequest payload) {
+        return JsonHelper.GSON.toJson(payload, DisconnectRequest.class);
+    }
+}

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/json/handshake/JsonHandshakeRequestDecoder.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/json/handshake/JsonHandshakeRequestDecoder.java
@@ -1,0 +1,12 @@
+package com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.handshake;
+
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.PayloadDecoder;
+import com.yahia.anotherchatapplicatoin.protocol.handshake.HandshakeRequest;
+import com.yahia.anotherchatapplicatoin.protocol.json.JsonHelper;
+
+public class JsonHandshakeRequestDecoder implements PayloadDecoder<HandshakeRequest> {
+    @Override
+    public HandshakeRequest decode(String raw) {
+        return JsonHelper.GSON.fromJson(raw, HandshakeRequest.class);
+    }
+}

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/json/handshake/JsonHandshakeRequestEncoder.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/json/handshake/JsonHandshakeRequestEncoder.java
@@ -1,0 +1,12 @@
+package com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.handshake;
+
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.PayloadEncoder;
+import com.yahia.anotherchatapplicatoin.protocol.handshake.HandshakeRequest;
+import com.yahia.anotherchatapplicatoin.protocol.json.JsonHelper;
+
+public class JsonHandshakeRequestEncoder implements PayloadEncoder<HandshakeRequest> {
+    @Override
+    public String encode(HandshakeRequest payload) {
+        return JsonHelper.GSON.toJson(payload, HandshakeRequest.class);
+    }
+}

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/json/handshake/JsonHandshakeResponseDecoder.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/json/handshake/JsonHandshakeResponseDecoder.java
@@ -1,0 +1,12 @@
+package com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.handshake;
+
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.PayloadDecoder;
+import com.yahia.anotherchatapplicatoin.protocol.handshake.HandshakeResponse;
+import com.yahia.anotherchatapplicatoin.protocol.json.JsonHelper;
+
+public class JsonHandshakeResponseDecoder implements PayloadDecoder<HandshakeResponse> {
+    @Override
+    public HandshakeResponse decode(String raw) {
+        return JsonHelper.GSON.fromJson(raw, HandshakeResponse.class);
+    }
+}

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/json/handshake/JsonHandshakeResponseEncoder.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/json/handshake/JsonHandshakeResponseEncoder.java
@@ -7,6 +7,6 @@ import com.yahia.anotherchatapplicatoin.protocol.json.JsonHelper;
 public class JsonHandshakeResponseEncoder implements PayloadEncoder<HandshakeResponse> {
     @Override
     public String encode(HandshakeResponse payload) {
-        return JsonHelper.GSON.toJson(payload.status(), HandshakeResponse.class);
+        return JsonHelper.GSON.toJson(payload, HandshakeResponse.class);
     }
 }

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/json/handshake/JsonHandshakeResponseEncoder.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/json/handshake/JsonHandshakeResponseEncoder.java
@@ -1,0 +1,12 @@
+package com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.handshake;
+
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.PayloadEncoder;
+import com.yahia.anotherchatapplicatoin.protocol.handshake.HandshakeResponse;
+import com.yahia.anotherchatapplicatoin.protocol.json.JsonHelper;
+
+public class JsonHandshakeResponseEncoder implements PayloadEncoder<HandshakeResponse> {
+    @Override
+    public String encode(HandshakeResponse payload) {
+        return JsonHelper.GSON.toJson(payload.status(), HandshakeResponse.class);
+    }
+}

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/json/messinging/JsonBroadcastMessageDecoder.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/json/messinging/JsonBroadcastMessageDecoder.java
@@ -1,0 +1,12 @@
+package com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.messinging;
+
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.PayloadDecoder;
+import com.yahia.anotherchatapplicatoin.protocol.json.JsonHelper;
+import com.yahia.anotherchatapplicatoin.protocol.messaging.BroadCastMessage;
+
+public class JsonBroadcastMessageDecoder implements PayloadDecoder<BroadCastMessage> {
+    @Override
+    public BroadCastMessage decode(String raw) {
+        return JsonHelper.GSON.fromJson(raw, BroadCastMessage.class);
+    }
+}

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/json/messinging/JsonBroadcastMessageEncoder.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/codec/payload/json/messinging/JsonBroadcastMessageEncoder.java
@@ -1,0 +1,12 @@
+package com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.messinging;
+
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.PayloadEncoder;
+import com.yahia.anotherchatapplicatoin.protocol.json.JsonHelper;
+import com.yahia.anotherchatapplicatoin.protocol.messaging.BroadCastMessage;
+
+public class JsonBroadcastMessageEncoder implements PayloadEncoder<BroadCastMessage> {
+    @Override
+    public String encode(BroadCastMessage payload) {
+        return JsonHelper.GSON.toJson(payload, BroadCastMessage.class);
+    }
+}

--- a/src/main/java/com/yahia/anotherchatapplicatoin/protocol/packet/CommunicationPacket.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/protocol/packet/CommunicationPacket.java
@@ -1,6 +1,7 @@
 package com.yahia.anotherchatapplicatoin.protocol.packet;
 
 //TODO: make generic <T>
+//TODO: payload should be an object, or some type that is have to be one of provided messages
 public record CommunicationPacket(
         PacketType type,
         String payload

--- a/src/main/java/com/yahia/anotherchatapplicatoin/server/Server.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/server/Server.java
@@ -1,10 +1,13 @@
 package com.yahia.anotherchatapplicatoin.server;
 
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.handshake.JsonHandshakeRequestDecoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.handshake.JsonHandshakeRequestEncoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.handshake.JsonHandshakeResponseEncoder;
 import com.yahia.anotherchatapplicatoin.server.accept.ServerConnectionContext;
 import com.yahia.anotherchatapplicatoin.server.accept.ServerPacketHandlerRegistry;
 import com.yahia.anotherchatapplicatoin.server.session.ServerClientHandler;
-import com.yahia.anotherchatapplicatoin.protocol.codec.JsonPacketDecoder;
-import com.yahia.anotherchatapplicatoin.protocol.codec.JsonPacketEncoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.packet.json.JsonPacketDecoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.packet.json.JsonPacketEncoder;
 import com.yahia.anotherchatapplicatoin.protocol.handshake.ConnectionStatus;
 import com.yahia.anotherchatapplicatoin.protocol.json.JsonHelper;
 import com.yahia.anotherchatapplicatoin.protocol.messaging.BroadCastMessage;
@@ -107,12 +110,16 @@ public class Server {
     }
 
     private void handleHandshakeRequest(ServerConnectionContext ctx) throws IOException {
-        CommunicationPacket packet = ctx.receiver().receive();
-
         LOGGER.log(Level.INFO, "Server Receives a HandShake Request");
-        HandshakeRequest request = JsonHelper.GSON.fromJson(packet.payload(), HandshakeRequest.class);
+        JsonHandshakeRequestDecoder decoder = new JsonHandshakeRequestDecoder();
+        JsonHandshakeResponseEncoder encoder = new JsonHandshakeResponseEncoder();
+
+        CommunicationPacket packet = ctx.receiver().receive();
+        HandshakeRequest request = decoder.decode(packet.payload());
         ConnectionStatus status = checkStatus(request);
-        String response = JsonHelper.GSON.toJson(new HandshakeResponse(status));
+
+        String response = encoder.encode(new HandshakeResponse(status));
+
 
         ctx.sender().send(new CommunicationPacket(PacketType.HANDSHAKE_RESPONSE, response));
 
@@ -139,8 +146,5 @@ public class Server {
             }
         }).start();
     }
-
-
-
-
+    
 }

--- a/src/main/java/com/yahia/anotherchatapplicatoin/server/Server.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/server/Server.java
@@ -3,6 +3,7 @@ package com.yahia.anotherchatapplicatoin.server;
 import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.handshake.JsonHandshakeRequestDecoder;
 import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.handshake.JsonHandshakeRequestEncoder;
 import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.handshake.JsonHandshakeResponseEncoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.messinging.JsonBroadcastMessageEncoder;
 import com.yahia.anotherchatapplicatoin.server.accept.ServerConnectionContext;
 import com.yahia.anotherchatapplicatoin.server.accept.ServerPacketHandlerRegistry;
 import com.yahia.anotherchatapplicatoin.server.session.ServerClientHandler;
@@ -61,7 +62,7 @@ public class Server {
             run();
             listen();
         }catch (IOException e) {
-            LOGGER.log(Level.SEVERE, String.format("Error creating server socket %s:%d", serverSocket.getInetAddress().getHostAddress(), this.SERVER_PORT));
+            LOGGER.log(Level.SEVERE, String.format("Error creating server socket %s:%d",SocketUtils.getServerSocketAddress(serverSocket), this.SERVER_PORT));
         }
     }
 
@@ -75,7 +76,8 @@ public class Server {
         CLIENTS.remove(clientHandler);
         CLIENT_NAMES.remove(clientUsername);
         LOGGER.log(Level.INFO, String.format("%s has disconnected", clientUsername));
-        String info = JsonHelper.GSON.toJson(new BroadCastMessage("SERVER", String.format("%s has been disconnected", clientUsername)));
+        JsonBroadcastMessageEncoder encoder = new JsonBroadcastMessageEncoder();
+        String info = encoder.encode(new BroadCastMessage("SERVER", String.format("%s has been disconnected", clientUsername)));
         broadCastPacket(new CommunicationPacket(PacketType.BROADCAST_MESSAGE, info));
     }
 
@@ -122,7 +124,7 @@ public class Server {
 
 
         ctx.sender().send(new CommunicationPacket(PacketType.HANDSHAKE_RESPONSE, response));
-
+        LOGGER.log(Level.INFO, String.format("Handshake status: %s", status));
         if(status == ConnectionStatus.ACCEPT) {
            handleAccept(ctx, request);
         }
@@ -139,6 +141,7 @@ public class Server {
             while(true) {
                 try {
                     Socket clientSocket = serverSocket.accept();
+                    LOGGER.log(Level.INFO, "Server receives a new connection");
                     handleClient(clientSocket);
                 }catch (IOException e) {
                     LOGGER.log(Level.WARNING, "Server couldn't connect to client");

--- a/src/main/java/com/yahia/anotherchatapplicatoin/server/session/ServerClientHandler.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/server/session/ServerClientHandler.java
@@ -1,5 +1,8 @@
 package com.yahia.anotherchatapplicatoin.server.session;
 
+import com.yahia.anotherchatapplicatoin.protocol.codec.packet.json.JsonPacketDecoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.packet.json.JsonPacketEncoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.disconnect.JsonDisconnectRequestDecoder;
 import com.yahia.anotherchatapplicatoin.protocol.disconnect.DisconnectRequest;
 import com.yahia.anotherchatapplicatoin.protocol.json.JsonHelper;
 import com.yahia.anotherchatapplicatoin.protocol.packet.CommunicationPacket;
@@ -39,8 +42,8 @@ public class ServerClientHandler implements Runnable {
 
 
     public void sendMessageToClient(CommunicationPacket packet) {
-        CommunicationPacket broadBastPacket = new CommunicationPacket(PacketType.BROADCAST_MESSAGE, packet.payload());
-        out.println(JsonHelper.GSON.toJson(broadBastPacket));
+        JsonPacketEncoder encoder = new JsonPacketEncoder();
+        out.println(encoder.encode(new CommunicationPacket(PacketType.BROADCAST_MESSAGE, packet.payload())));
         LOGGER.log(Level.INFO, String.format("Message delivered to client %s successfully", SocketUtils.getSocketAddress(CLIENT_SOCKET)));
     }
 
@@ -63,7 +66,8 @@ public class ServerClientHandler implements Runnable {
 
     }
     private void handleDisconnection(CommunicationPacket packet) {
-        DisconnectRequest request = JsonHelper.GSON.fromJson(packet.payload(), DisconnectRequest.class);
+        JsonDisconnectRequestDecoder decoder = new JsonDisconnectRequestDecoder();
+        DisconnectRequest request = decoder.decode(packet.payload());
         CHAT_SERVER.removeClient(this, request.username());
     }
 
@@ -71,11 +75,12 @@ public class ServerClientHandler implements Runnable {
     public void run() {
         try {
             BufferedReader in = new BufferedReader(new InputStreamReader(CLIENT_SOCKET.getInputStream()));
+            JsonPacketDecoder packetDecoder = new JsonPacketDecoder();
             String msg;
             while((msg = in.readLine()) != null) {
-                LOGGER.log(Level.INFO, String.format("Server received a message: %s from %s", msg, CLIENT_SOCKET.getInetAddress().getHostAddress()));
-                CommunicationPacket clientPacket =  JsonHelper.GSON.fromJson(msg, CommunicationPacket.class);
-                handlerRegistry.get(clientPacket.type()).handlePacket(clientPacket);
+                LOGGER.log(Level.INFO, String.format("Server received a message: %s from %s", msg, SocketUtils.getSocketAddress(CLIENT_SOCKET)));
+                CommunicationPacket clientPacket =  packetDecoder.decode(msg);
+                handlerRegistry.get(clientPacket.type()).handlePacket(packetDecoder.decode(msg));
             }
         }catch (IOException e) {
             LOGGER.log(Level.WARNING, "Server couldn't receive client message");

--- a/src/main/java/com/yahia/anotherchatapplicatoin/transport/tcp/SocketMessageReceiver.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/transport/tcp/SocketMessageReceiver.java
@@ -1,12 +1,11 @@
 package com.yahia.anotherchatapplicatoin.transport.tcp;
 
-import com.yahia.anotherchatapplicatoin.protocol.codec.PacketDecoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.packet.PacketDecoder;
 import com.yahia.anotherchatapplicatoin.protocol.messaging.MessageReceiver;
 import com.yahia.anotherchatapplicatoin.protocol.packet.CommunicationPacket;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 public class SocketMessageReceiver implements MessageReceiver {
     private final BufferedReader in;

--- a/src/main/java/com/yahia/anotherchatapplicatoin/transport/tcp/SocketMessageSender.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/transport/tcp/SocketMessageSender.java
@@ -1,12 +1,10 @@
 package com.yahia.anotherchatapplicatoin.transport.tcp;
 
-import com.yahia.anotherchatapplicatoin.protocol.codec.PacketEncoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.packet.PacketEncoder;
 import com.yahia.anotherchatapplicatoin.protocol.messaging.MessageSender;
 import com.yahia.anotherchatapplicatoin.protocol.packet.CommunicationPacket;
 
-import javax.swing.plaf.nimbus.State;
 import java.io.PrintWriter;
-import java.util.UUID;
 
 public class SocketMessageSender implements MessageSender {
     private final PrintWriter out;

--- a/src/main/java/com/yahia/anotherchatapplicatoin/ui/controllers/LoginSceneController.java
+++ b/src/main/java/com/yahia/anotherchatapplicatoin/ui/controllers/LoginSceneController.java
@@ -2,6 +2,9 @@ package com.yahia.anotherchatapplicatoin.ui.controllers;
 
 
 import com.yahia.anotherchatapplicatoin.client.Client;
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.handshake.JsonHandshakeRequestEncoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.handshake.JsonHandshakeResponseDecoder;
+import com.yahia.anotherchatapplicatoin.protocol.codec.payload.json.handshake.JsonHandshakeResponseEncoder;
 import com.yahia.anotherchatapplicatoin.protocol.disconnect.DisconnectReason;
 import com.yahia.anotherchatapplicatoin.protocol.handshake.ConnectionStatus;
 import com.yahia.anotherchatapplicatoin.protocol.json.JsonHelper;
@@ -43,7 +46,8 @@ public class LoginSceneController implements LoginSceneListener {
         });
     }
     private void sendHandShake() {
-        String username = JsonHelper.GSON.toJson(new HandshakeRequest(client.getClientName()));
+        JsonHandshakeRequestEncoder encoder = new JsonHandshakeRequestEncoder();
+        String username = encoder.encode(new HandshakeRequest(client.getClientName()));
         client.sendMessage(new CommunicationPacket(PacketType.HANDSHAKE_REQUEST, username));
     }
 


### PR DESCRIPTION
## Payload-Level Encoders & Decoders

### Summary

Introducing **payload-level encoding and decoding abstractions** to the protocol layer.  
It's job is to separate **packet envelope serialization** from **payload serialization**
---

### Motivation
Previously, encoding and decoding were focused on the `CommunicationPacket` as a whole.  
As the protocol expands (handshake, disconnect, messaging, etc.), each payload type requires its **own serialization logic** without overloading packet-level codecs.

This change is mainly made for:
- Preparing the protocol for future encoding formats, for now it's JSON, later it may be Protobuffs, ...etc

---

### What’s new ?
- Added generic payload codec contracts:
  - `PayloadEncoder<T>`
  - `PayloadDecoder<T>`
- Implemented JSON-based payload encoders and decoders for existing payload types
- Integrated payload codecs with existing packet encoding/decoding flow